### PR TITLE
remove `documentID` from `FirestoreDocument` protocol

### DIFF
--- a/Sources/SwiftyFirestore/Protocol/FirestoreDocument.swift
+++ b/Sources/SwiftyFirestore/Protocol/FirestoreDocument.swift
@@ -14,7 +14,6 @@ public protocol FirestoreDocument: Codable {
 
     static var collectionID: String { get }
 
-    var documentID: String! { get set }
     var documentReference: DocumentRef<Self>! { get set }
 
     init(_ snapshot: QueryDocumentSnapshot) throws
@@ -33,7 +32,6 @@ extension FirestoreDocument {
     public init(_ snapshot: QueryDocumentSnapshot) throws {
         do {
             var document = try Firestore.Decoder().decode(Self.self, from: snapshot.data())
-            document.documentID = snapshot.documentID
             document.documentReference = DocumentRef(ref: snapshot.reference)
             self = document
         } catch {
@@ -45,7 +43,6 @@ extension FirestoreDocument {
         guard let data = snapshot.data() else { return nil }
         do {
             var document = try Firestore.Decoder().decode(Self.self, from: data)
-            document.documentID = snapshot.documentID
             document.documentReference = DocumentRef(ref: snapshot.reference)
             self = document
         } catch {

--- a/SwiftyFirestore.xcodeproj/project.pbxproj
+++ b/SwiftyFirestore.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		E56EA5D32440A4A4008E13C0 /* Alias.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56EA5D22440A4A4008E13C0 /* Alias.swift */; };
 		E56EA5D52440A665008E13C0 /* AliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56EA5D42440A665008E13C0 /* AliasTests.swift */; };
 		E57DE0062434A4E300308FC0 /* libSwiftyFirestore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5584A602434A3DD007035B6 /* libSwiftyFirestore.a */; };
-		E57DE0122434A54500308FC0 /* SwiftyFirestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57DE0102434A54500308FC0 /* SwiftyFirestoreTests.swift */; };
 		E57DE01C2434A6A000308FC0 /* QueryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57DE0162434A6A000308FC0 /* QueryWrapper.swift */; };
 		E57DE01D2434A6A000308FC0 /* DocumentRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57DE0172434A6A000308FC0 /* DocumentRef.swift */; };
 		E57DE01E2434A6A000308FC0 /* QueryRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57DE0182434A6A000308FC0 /* QueryRef.swift */; };
@@ -573,7 +572,6 @@
 				E5502CA42435E121007EC1F1 /* FirestoreTestHelper.swift in Sources */,
 				E5502C9C2435DBF0007EC1F1 /* FirestoreDocuments.swift in Sources */,
 				E51609342442B9FA005A7B87 /* AddDocumentTests.swift in Sources */,
-				E57DE0122434A54500308FC0 /* SwiftyFirestoreTests.swift in Sources */,
 				E5502CA12435DC88007EC1F1 /* FirestoreRelationAlias.swift in Sources */,
 				E53892A8243FE03500F72573 /* XCTestCase+.swift in Sources */,
 			);


### PR DESCRIPTION
Because supported in officially.
https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/Swift/Source/Codable/DocumentID.swift