### PR TITLE
Fixing decoding error when using DocumentReference

### DIFF
--- a/Sources/SwiftyFirestore/Document/DocumentRef.swift
+++ b/Sources/SwiftyFirestore/Document/DocumentRef.swift
@@ -24,8 +24,8 @@ public class DocumentRef<Document: FirestoreDocument>: DocumentRefProtocol, Coda
     }
 
     public required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        ref = try values.decode(DocumentReference.self, forKey: .ref)
+        let values = try decoder.singleValueContainer()
+        ref = try values.decode(DocumentReference.self)
     }
 }
 


### PR DESCRIPTION
## Issue

Decoding error occurs when using DocumentReference. 
The reason is why the data is decoded as dictionary even it's not dictionary.

## Solution

The solution is using `singleValueContainer` to decode the data instead of `container(keyedBy: CodingKeys.self)` .
