### PR TITLE
Using singleValueContainer when encoding DocumentRef

### DIFF
--- a/Sources/SwiftyFirestore/Document/DocumentRef.swift
+++ b/Sources/SwiftyFirestore/Document/DocumentRef.swift
@@ -27,6 +27,11 @@ public class DocumentRef<Document: FirestoreDocument>: DocumentRefProtocol, Coda
         let values = try decoder.singleValueContainer()
         ref = try values.decode(DocumentReference.self)
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(ref)
+    }
 }
 
 extension DocumentRef: Equatable {

--- a/Sources/SwiftyFirestore/Document/DocumentRef.swift
+++ b/Sources/SwiftyFirestore/Document/DocumentRef.swift
@@ -11,10 +11,6 @@ import FirebaseFirestore
 public class DocumentRef<Document: FirestoreDocument>: DocumentRefProtocol, Codable {
     public let ref: DocumentReference
 
-//    public init(_ ref: DocumentReference) {
-//        self.ref = ref
-//    }
-
     public init(_ ref: Firestore, id: String) {
         self.ref = ref.collection(Document.collectionID).document(id)
     }


### PR DESCRIPTION
## What

Decoding error in DocumentRef was fixed by https://github.com/YusukeHosonuma/SwiftyFirestore/pull/54 .
About encoding, there is a similar problem.